### PR TITLE
refactor: Entity 구성 수정

### DIFF
--- a/backend/src/main/java/oo/kr/shared/domain/payment/domain/Payment.java
+++ b/backend/src/main/java/oo/kr/shared/domain/payment/domain/Payment.java
@@ -1,5 +1,6 @@
 package oo.kr.shared.domain.payment.domain;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -17,13 +18,17 @@ import oo.kr.shared.global.type.BaseEntity;
 @Entity
 public class Payment extends BaseEntity {
 
+  @Column(nullable = false, unique = true)
   private String impUid;
 
+  @Column(nullable = false, unique = true)
   private String merchantUid;
 
+  @Column(nullable = false)
   private Integer amount;
 
   @Enumerated(EnumType.STRING)
+  @Column(nullable = false)
   private PaymentStatus paymentStatus = PaymentStatus.COMPLETED;
 
   @ManyToOne

--- a/backend/src/main/java/oo/kr/shared/domain/rentalrecord/domain/RentalRecord.java
+++ b/backend/src/main/java/oo/kr/shared/domain/rentalrecord/domain/RentalRecord.java
@@ -7,6 +7,7 @@ import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToOne;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
@@ -23,31 +24,32 @@ import oo.kr.shared.global.type.BaseEntity;
 @Entity
 public class RentalRecord extends BaseEntity {
 
-  @Column(columnDefinition = "datetime")
+  @Column(nullable = false, columnDefinition = "datetime")
   private LocalDateTime rentalTime;
 
   @Column(columnDefinition = "datetime")
   private LocalDateTime returnTime;
 
-  @Column(columnDefinition = "datetime")
+  @Column(nullable = false, columnDefinition = "datetime")
   private LocalDateTime expectedReturnTime;
 
   @Enumerated(EnumType.STRING)
+  @Column(nullable = false)
   private RentalStatus rentalStatus = RentalStatus.RENTED;
 
   @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
   @JoinColumn(name = "payment_id")
   private Payment payment;
 
-  @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.MERGE)
+  @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "umbrella_id")
   private Umbrella umbrella;
 
-  @OneToOne(fetch = FetchType.LAZY)
+  @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "rental_station_id")
   private RentalStation rentalStation;
 
-  @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.MERGE)
+  @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "return_station_id")
   private RentalStation returnStation;
 

--- a/backend/src/main/java/oo/kr/shared/domain/rentalstation/domain/RentalStation.java
+++ b/backend/src/main/java/oo/kr/shared/domain/rentalstation/domain/RentalStation.java
@@ -1,6 +1,8 @@
 package oo.kr.shared.domain.rentalstation.domain;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.OneToMany;
 import java.util.ArrayList;
 import java.util.List;
@@ -17,10 +19,16 @@ import org.locationtech.jts.geom.Point;
 @Entity
 public class RentalStation extends BaseEntity {
 
+  @Column(nullable = false)
   private String name;
+
+  @Column(nullable = false)
   private String address;
-  @OneToMany(mappedBy = "currentStation")
+
+  @OneToMany(mappedBy = "currentStation", fetch = FetchType.LAZY)
   private List<Umbrella> availableUmbrellas = new ArrayList<>();
+
+  @Column(nullable = false)
   private Point point;
 
   public RentalStation(String name, String address, Double latitude, Double longitude) {

--- a/backend/src/main/java/oo/kr/shared/domain/umbrella/domain/Umbrella.java
+++ b/backend/src/main/java/oo/kr/shared/domain/umbrella/domain/Umbrella.java
@@ -1,5 +1,6 @@
 package oo.kr.shared.domain.umbrella.domain;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -18,6 +19,7 @@ import oo.kr.shared.global.type.BaseEntity;
 public class Umbrella extends BaseEntity {
 
   @Enumerated(EnumType.STRING)
+  @Column(nullable = false)
   private UmbrellaStatus umbrellaStatus;
 
   @ManyToOne(fetch = FetchType.LAZY)

--- a/backend/src/main/java/oo/kr/shared/domain/user/domain/User.java
+++ b/backend/src/main/java/oo/kr/shared/domain/user/domain/User.java
@@ -1,5 +1,6 @@
 package oo.kr.shared.domain.user.domain;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -13,13 +14,23 @@ import oo.kr.shared.global.type.BaseEntity;
 @Entity
 public class User extends BaseEntity {
 
+  @Column(nullable = false)
   private String nickName;
+
+  @Column(nullable = false)
   private String password;
+
+  @Column(nullable = false, unique = true)
   private String email;
+
   private String image;
+
   @Enumerated(EnumType.STRING)
+  @Column(nullable = false)
   private ProviderType providerType = ProviderType.LOCAL;
+
   @Enumerated(EnumType.STRING)
+  @Column(nullable = false)
   private Role role = Role.USER;
 
   public User(String email, String password) {

--- a/backend/src/main/java/oo/kr/shared/global/type/BaseEntity.java
+++ b/backend/src/main/java/oo/kr/shared/global/type/BaseEntity.java
@@ -20,11 +20,11 @@ public abstract class BaseEntity {
   private Long id;
 
   @CreatedDate
-  @Column(name = "create_date", updatable = false, columnDefinition = "datetime default now()")
+  @Column(name = "create_date", updatable = false, nullable = false, columnDefinition = "datetime default now()")
   private LocalDateTime createDate;
 
   @LastModifiedDate
-  @Column(name = "update_date", columnDefinition = "datetime default now()")
+  @Column(name = "update_date", nullable = false, columnDefinition = "datetime default now()")
   private LocalDateTime updateDate;
 
   protected BaseEntity() {


### PR DESCRIPTION
## 잘못 설정된 연관관계 수정
### RentalRecord 
- RentalStation(대여장소) , ReturnStation(반납장소) 연관관계가 OneToOne으로 잘못 설계
- RentalRecord `Many` - `One` RentalStation or ReturnStation 으로 연관관계 수정

### Entity 제약조건 추가
- `not null`  `unique` 등 필수 제약조건 추가