### PR TITLE
fix: oauth2 url 수정

### DIFF
--- a/backend/src/main/java/oo/kr/shared/global/security/config/SecurityConfig.java
+++ b/backend/src/main/java/oo/kr/shared/global/security/config/SecurityConfig.java
@@ -87,8 +87,6 @@ public class SecurityConfig {
         .requestMatchers(PathRequest.toStaticResources()
                                     .atCommonLocations())
         .permitAll()
-        .requestMatchers("/api/login/**")
-        .permitAll()
         .requestMatchers("/api/accounts/**")
         .permitAll()
         .requestMatchers(HttpMethod.GET, "/api/rentals/umbrellas/**")

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -91,9 +91,9 @@ spring:
       client:
         registration:
           google:
-            redirect-uri: http://raincatch.site/api/login/oauth2/code/google
+            redirect-uri: http://raincatch.site/login/oauth2/code/google
           kakao:
-            redirect-uri: http://raincatch.site/api/login/oauth2/code/kakao
+            redirect-uri: http://raincatch.site/login/oauth2/code/kakao
 login:
   redirect-url: http://raincatch.site/login-success
 ---


### PR DESCRIPTION
- nginx에서 설정값을 수정하였습니다. Spring Security의 기본 oauth2 redirect-url matcher인 `/login/auth2/code` 를 8080포트로 리버스 프록시 하도록 수정하였습니다.
- 이에 따라 이전 pr에서 수정하였던 SpringSecurity redirect-uri를 원상복구 하였습니다.