### PR TITLE
fix: JWT 액세스토큰 저장 장소 수정

### DIFF
--- a/backend/src/main/java/oo/kr/shared/domain/payment/controller/PaymentController.java
+++ b/backend/src/main/java/oo/kr/shared/domain/payment/controller/PaymentController.java
@@ -3,6 +3,7 @@ package oo.kr.shared.domain.payment.controller;
 import lombok.RequiredArgsConstructor;
 import oo.kr.shared.domain.payment.controller.request.RequiredAmount;
 import oo.kr.shared.domain.payment.controller.request.RequiredPaymentData;
+import oo.kr.shared.domain.payment.controller.response.PreRegisterPaymentInfo;
 import oo.kr.shared.domain.payment.service.PaymentService;
 import oo.kr.shared.global.portone.PreRegisterPaymentData;
 import oo.kr.shared.global.portone.SinglePaymentInfo;
@@ -26,10 +27,10 @@ public class PaymentController {
    * 결제금액 사전등록 API
    */
   @PostMapping("/pre-registration")
-  public ResponseEntity<PreRegisterPaymentData> preRegisterPayment(@RequestBody RequiredAmount requiredAmount) {
+  public ResponseEntity<PreRegisterPaymentInfo> preRegisterPayment(@RequestBody RequiredAmount requiredAmount) {
     String email = SecurityUtils.getAuthenticationPrincipal();
     PreRegisterPaymentData preRegisterResult = paymentService.preRegisterPayment(email, requiredAmount.amount());
-    return ResponseEntity.ok(preRegisterResult);
+    return ResponseEntity.ok(new PreRegisterPaymentInfo(email, preRegisterResult));
   }
 
   /**

--- a/backend/src/main/java/oo/kr/shared/domain/payment/controller/response/PreRegisterPaymentInfo.java
+++ b/backend/src/main/java/oo/kr/shared/domain/payment/controller/response/PreRegisterPaymentInfo.java
@@ -1,0 +1,12 @@
+package oo.kr.shared.domain.payment.controller.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import oo.kr.shared.global.portone.PreRegisterPaymentData;
+
+public record PreRegisterPaymentInfo(
+    String email,
+    @JsonProperty("payment_data")
+    PreRegisterPaymentData paymentData
+) {
+
+}

--- a/backend/src/main/java/oo/kr/shared/domain/user/controller/UserController.java
+++ b/backend/src/main/java/oo/kr/shared/domain/user/controller/UserController.java
@@ -3,12 +3,15 @@ package oo.kr.shared.domain.user.controller;
 import lombok.RequiredArgsConstructor;
 import oo.kr.shared.domain.user.controller.response.RentalRecordData;
 import oo.kr.shared.domain.user.service.UserService;
+import oo.kr.shared.global.type.ResponseType;
+import oo.kr.shared.global.type.SimpleResponse;
 import oo.kr.shared.global.utils.SecurityUtils;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
+import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -29,5 +32,12 @@ public class UserController {
     String email = SecurityUtils.getAuthenticationPrincipal();
     Page<RentalRecordData> rentalRecordData = userService.viewRentalRecord(email, pageable);
     return ResponseEntity.ok(rentalRecordData);
+  }
+
+  @GetMapping("/me")
+  public ResponseEntity<SimpleResponse> checkAuth() {
+    String email = SecurityUtils.getAuthenticationPrincipal();
+    ResponseType responseType = StringUtils.hasText(email) ? ResponseType.SUCCESS : ResponseType.FAIL;
+    return ResponseEntity.ok(new SimpleResponse(responseType));
   }
 }

--- a/backend/src/main/java/oo/kr/shared/global/security/config/SecurityConfig.java
+++ b/backend/src/main/java/oo/kr/shared/global/security/config/SecurityConfig.java
@@ -75,7 +75,6 @@ public class SecurityConfig {
     configuration.setMaxAge(3600L);
     // Authorization header Read 권한 추가
     configuration.addExposedHeader(HttpHeaders.AUTHORIZATION);
-    configuration.applyPermitDefaultValues();
 
     UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
     source.registerCorsConfiguration("/**", configuration);
@@ -84,12 +83,15 @@ public class SecurityConfig {
 
   private void configureAuthorizeRequestMatcher(HttpSecurity http) throws Exception {
     http.authorizeHttpRequests(requestRegistry -> requestRegistry
-        .requestMatchers(PathRequest.toStaticResources()
-                                    .atCommonLocations())
+        .requestMatchers(PathRequest.toStaticResources().atCommonLocations())
         .permitAll()
         .requestMatchers("/api/accounts/**")
         .permitAll()
         .requestMatchers(HttpMethod.GET, "/api/rentals/umbrellas/**")
+        .permitAll()
+        .requestMatchers(HttpMethod.GET, "/api/stations/near")
+        .permitAll()
+        .requestMatchers(HttpMethod.GET, "/api/stations/**")
         .permitAll()
         .anyRequest()
         .authenticated());

--- a/backend/src/main/java/oo/kr/shared/global/security/filter/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/oo/kr/shared/global/security/filter/JwtAuthenticationFilter.java
@@ -9,15 +9,17 @@ import java.util.Arrays;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import oo.kr.shared.global.exception.type.jwt.InvalidJwtException;
+import oo.kr.shared.global.security.jwt.CookieManager;
 import oo.kr.shared.global.security.jwt.JwtProvider;
 import oo.kr.shared.global.security.jwt.JwtResultType;
-import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
-import org.springframework.util.StringUtils;
+import org.springframework.util.AntPathMatcher;
+import org.springframework.util.PathMatcher;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 @Component
@@ -25,32 +27,46 @@ import org.springframework.web.filter.OncePerRequestFilter;
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
   private final JwtProvider jwtProvider;
+  private final PathMatcher pathMatcher = new AntPathMatcher();
+  private final List<EndPoint> tokenFreeEndPoints = List.of(
+      new EndPoint("/api/accounts/duplicate", HttpMethod.GET),
+      new EndPoint("/api/accounts/signup", HttpMethod.POST),
+      new EndPoint("/api/accounts/login", HttpMethod.POST),
+      new EndPoint("/api/rentals/umbrellas/*", HttpMethod.GET),
+      new EndPoint("/api/stations/*", HttpMethod.GET)
+  );
 
   @Override
   protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
       throws ServletException, IOException {
-    String bearerToken = request.getHeader(HttpHeaders.AUTHORIZATION);
-    if (!StringUtils.hasText(bearerToken)) {
+    String requestURI = request.getRequestURI();
+    String method = request.getMethod().toUpperCase();
+    if (isTokenFreeEndPoint(requestURI, method)) {
       doFilter(request, response, filterChain);
       return;
     }
+    String token = CookieManager.getAccessToken(request);
 
-    String token = JwtProvider.getJwt(bearerToken);
-
-    if (StringUtils.hasText(token)) {
-      JwtResultType jwtResultType = jwtProvider.verifyToken(token);
-      switch (jwtResultType) {
-        case VALID_JWT -> {
-          saveAuthentication(token);
-          filterChain.doFilter(request, response);
-        }
-        case EXPIRED_JWT -> {
-          refreshAccessToken(token, response);
-          filterChain.doFilter(request, response);
-        }
-        case INVALID_JWT -> throw new InvalidJwtException();
+    JwtResultType jwtResultType = jwtProvider.verifyToken(token);
+    switch (jwtResultType) {
+      case VALID_JWT -> {
+        saveAuthentication(token);
+        filterChain.doFilter(request, response);
       }
+      case EXPIRED_JWT -> {
+        refreshAccessToken(token, response);
+        filterChain.doFilter(request, response);
+      }
+      case INVALID_JWT -> throw new InvalidJwtException();
     }
+  }
+
+  private boolean isTokenFreeEndPoint(String requestURI, String requestMethod) {
+    return tokenFreeEndPoints.stream()
+                             .anyMatch(endpoint ->
+                                 pathMatcher.match(endpoint.pattern, requestURI)
+                                     && endpoint.method.matches(requestMethod));
+
   }
 
   private void saveAuthentication(String token) {
@@ -66,7 +82,14 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
   private void refreshAccessToken(String token, HttpServletResponse response) {
     String accessToken = jwtProvider.refreshAccessToken(token);
-    response.setHeader(HttpHeaders.AUTHORIZATION, accessToken);
+    CookieManager.createJWTCookie(response, accessToken);
     saveAuthentication(accessToken);
+  }
+
+  private record EndPoint(
+      String pattern,
+      HttpMethod method
+  ) {
+
   }
 }

--- a/backend/src/main/java/oo/kr/shared/global/security/handler/SecurityLoginSuccessHandler.java
+++ b/backend/src/main/java/oo/kr/shared/global/security/handler/SecurityLoginSuccessHandler.java
@@ -1,25 +1,22 @@
 package oo.kr.shared.global.security.handler;
 
-import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import lombok.RequiredArgsConstructor;
 import oo.kr.shared.domain.user.domain.ProviderType;
 import oo.kr.shared.global.security.auth.PrincipalDetails;
 import oo.kr.shared.global.security.auth.SecurityUserInfo;
+import oo.kr.shared.global.security.jwt.CookieManager;
 import oo.kr.shared.global.security.jwt.GeneratedToken;
 import oo.kr.shared.global.security.jwt.JwtProvider;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.DefaultRedirectStrategy;
 import org.springframework.security.web.RedirectStrategy;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
-import org.springframework.web.util.UriComponentsBuilder;
 
 @Component
 @RequiredArgsConstructor
@@ -32,31 +29,24 @@ public class SecurityLoginSuccessHandler implements AuthenticationSuccessHandler
 
   @Override
   public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
-      Authentication authentication) throws IOException, ServletException {
+      Authentication authentication) throws IOException {
     GeneratedToken generatedToken = jwtProvider.generateToken(authentication);
     PrincipalDetails user = (PrincipalDetails) authentication.getPrincipal();
     SecurityUserInfo userInfo = user.getSecurityUserInfo();
     ProviderType providerType = userInfo.providerType();
+    CookieManager.createJWTCookie(response, generatedToken.accessToken());
     if (providerType.equals(ProviderType.LOCAL)) {
-      jsonLoginSuccessProcess(response, generatedToken);
+      jsonLoginSuccessProcess(response);
     } else {
-      oAuth2LoginSuccessProcess(request, response, generatedToken);
+      oAuth2LoginSuccessProcess(request, response);
     }
   }
 
-  private void jsonLoginSuccessProcess(HttpServletResponse response, GeneratedToken generatedToken) {
-    response.setHeader(HttpHeaders.AUTHORIZATION, generatedToken.accessToken());
+  private void jsonLoginSuccessProcess(HttpServletResponse response) {
     response.setStatus(HttpStatus.OK.value());
   }
 
-  private void oAuth2LoginSuccessProcess(HttpServletRequest request, HttpServletResponse response,
-      GeneratedToken generatedToken)
-      throws IOException {
-    String targetUrl = UriComponentsBuilder.fromUriString(redirectUrl)
-                                           .queryParam("accessToken", generatedToken.accessToken())
-                                           .build()
-                                           .encode(StandardCharsets.UTF_8)
-                                           .toUriString();
-    redirectStrategy.sendRedirect(request, response, targetUrl);
+  private void oAuth2LoginSuccessProcess(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    redirectStrategy.sendRedirect(request, response, redirectUrl);
   }
 }

--- a/backend/src/main/java/oo/kr/shared/global/security/handler/SecurityLogoutHandler.java
+++ b/backend/src/main/java/oo/kr/shared/global/security/handler/SecurityLogoutHandler.java
@@ -3,9 +3,9 @@ package oo.kr.shared.global.security.handler;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import oo.kr.shared.global.security.jwt.CookieManager;
 import oo.kr.shared.global.security.jwt.JwtProvider;
 import oo.kr.shared.global.security.jwt.RefreshTokenService;
-import org.springframework.http.HttpHeaders;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.logout.LogoutHandler;
 import org.springframework.stereotype.Component;
@@ -15,11 +15,12 @@ import org.springframework.stereotype.Component;
 public class SecurityLogoutHandler implements LogoutHandler {
 
   private final RefreshTokenService tokenService;
+  private final JwtProvider jwtProvider;
 
   @Override
   public void logout(HttpServletRequest request, HttpServletResponse response, Authentication authentication) {
-    String bearerToken = request.getHeader(HttpHeaders.AUTHORIZATION);
-    String accessToken = JwtProvider.getJwt(bearerToken);
-    tokenService.removeRefreshToken(accessToken);
+    String accessToken = CookieManager.getAccessToken(request);
+    String email = jwtProvider.getUid(accessToken);
+    tokenService.removeRefreshToken(email);
   }
 }

--- a/backend/src/main/java/oo/kr/shared/global/security/jwt/CookieManager.java
+++ b/backend/src/main/java/oo/kr/shared/global/security/jwt/CookieManager.java
@@ -1,0 +1,41 @@
+package oo.kr.shared.global.security.jwt;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Optional;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class CookieManager {
+
+  private static final String COOKIE_NAME = "AccessToken";
+
+  public static void createJWTCookie(HttpServletResponse response, String accessToken) {
+    ResponseCookie cookie = ResponseCookie.from(COOKIE_NAME, accessToken)
+                                          .httpOnly(true)
+                                          .maxAge(Duration.ofDays(14L))
+                                          .sameSite("Strict")
+                                          .path("/")
+                                          .build();
+    response.setHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+  }
+
+  public static String getAccessToken(HttpServletRequest request) {
+    return Optional.ofNullable(request.getCookies())
+                   .flatMap(CookieManager::getCookieValue)
+                   .orElse(null);
+  }
+
+  private static Optional<String> getCookieValue(Cookie[] cookies) {
+    return Arrays.stream(cookies)
+                 .filter(cookie -> cookie.getName().equals(COOKIE_NAME))
+                 .map(Cookie::getValue)
+                 .findFirst();
+  }
+}

--- a/backend/src/main/java/oo/kr/shared/global/security/jwt/RefreshToken.java
+++ b/backend/src/main/java/oo/kr/shared/global/security/jwt/RefreshToken.java
@@ -4,7 +4,6 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.redis.core.RedisHash;
-import org.springframework.data.redis.core.index.Indexed;
 
 @Getter
 @AllArgsConstructor
@@ -14,12 +13,6 @@ public class RefreshToken {
   @Id
   private String id;
 
-  @Indexed
-  private String accessToken;
-
   private String refreshToken;
 
-  public void updateAccessToken(String accessToken) {
-    this.accessToken = accessToken;
-  }
 }

--- a/backend/src/main/java/oo/kr/shared/global/security/jwt/RefreshTokenRepository.java
+++ b/backend/src/main/java/oo/kr/shared/global/security/jwt/RefreshTokenRepository.java
@@ -1,12 +1,9 @@
 package oo.kr.shared.global.security.jwt;
 
-import java.util.Optional;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface RefreshTokenRepository extends CrudRepository<RefreshToken, String> {
-
-  Optional<RefreshToken> findByAccessToken(String accessToken);
 
 }

--- a/backend/src/main/java/oo/kr/shared/global/security/jwt/RefreshTokenService.java
+++ b/backend/src/main/java/oo/kr/shared/global/security/jwt/RefreshTokenService.java
@@ -13,24 +13,18 @@ public class RefreshTokenService {
   private final RefreshTokenRepository refreshTokenRepository;
 
   @Transactional
-  public void saveTokenInfo(String email, String refreshToken, String accessToken) {
-    refreshTokenRepository.save(new RefreshToken(email, accessToken, refreshToken));
+  public void saveTokenInfo(String email, String refreshToken) {
+    refreshTokenRepository.save(new RefreshToken(email, refreshToken));
   }
 
   @Transactional
-  public void saveTokenInfo(RefreshToken refreshToken) {
-    refreshTokenRepository.save(refreshToken);
+  public RefreshToken findTokenInfo(String email) {
+    return refreshTokenRepository.findById(email).orElseThrow(ExpiredRefreshTokenException::new);
   }
 
   @Transactional
-  public RefreshToken findTokenInfo(String accessToken) {
-    return refreshTokenRepository.findByAccessToken(accessToken)
-                                 .orElseThrow(ExpiredRefreshTokenException::new);
-  }
-
-  @Transactional
-  public void removeRefreshToken(String accessToken) {
-    Optional<RefreshToken> optionalRefreshToken = refreshTokenRepository.findByAccessToken(accessToken);
+  public void removeRefreshToken(String email) {
+    Optional<RefreshToken> optionalRefreshToken = refreshTokenRepository.findById(email);
     if (optionalRefreshToken.isEmpty()) {
       return;
     }

--- a/frontend/src/components/LoginSuccess.js
+++ b/frontend/src/components/LoginSuccess.js
@@ -7,11 +7,7 @@ function LoginSuccess() {
   const {state} = useLocation();
 
   useEffect(() => {
-    let accessToken = query.get('accessToken');
-    if (accessToken) {
-      sessionStorage.setItem('jwt', accessToken);
-      navigate(state ? state : '/');
-    }
+    navigate(state ? state : '/');
   }, [state, navigate, query]);
 
   return (

--- a/frontend/src/components/PrivateLayout.js
+++ b/frontend/src/components/PrivateLayout.js
@@ -1,14 +1,23 @@
 import {Outlet, useLocation, useNavigate} from "react-router-dom";
 import {useEffect} from "react";
+import customAxios from "../modules/Axios_interceptor";
 
 const PrivateLayout = () => {
   let navigate = useNavigate();
   let {pathname} = useLocation();
 
   useEffect(() => {
-    if (!sessionStorage.getItem('jwt')) {
+    customAxios.get('/api/users/me').then(response => response.data)
+    .then(data => {
+      if (data.result !== 'SUCCESS') {
+        navigate('/accounts/login', {state: pathname});
+      }
+    })
+    .catch(error => {
+      const data = error.response.data;
+      alert(data.errorDetail.message);
       navigate('/accounts/login', {state: pathname});
-    }
+    });
   }, [navigate, pathname]);
 
   return (

--- a/frontend/src/modules/Axios_interceptor.js
+++ b/frontend/src/modules/Axios_interceptor.js
@@ -2,51 +2,10 @@ import axios from "axios";
 
 const customAxios = axios.create();
 
-const tokenFreeEndPoints = [
-  {pattern: /^\/api\/accounts\/duplicate$/, method: 'GET'},
-  {pattern: /^\/api\/accounts\/signup$/, method: 'POST'},
-  {pattern: /^\/api\/accounts\/login$/, method: 'POST'},
-  {pattern: /^\/api\/rentals\/umbrellas\/\d+$/, method: 'GET'},
-  {pattern: /^\/api\/rental-stations\/\d+$/, method: 'GET'},
-  {pattern: /^\/api\/stations\/near$/, method: 'GET'}
-]
-
-customAxios.interceptors.request.use(
-    request => {
-      let isRequiredToken = true;
-      const requestMethod = request.method.toUpperCase();
-      tokenFreeEndPoints.forEach(({pattern, method}) => {
-        if (pattern.test(request.url) && method === requestMethod) {
-          isRequiredToken = false;
-        }
-      })
-
-      if (isRequiredToken) {
-        const accessToken = sessionStorage.getItem('jwt');
-        if (accessToken) {
-          request.headers['Authorization'] = `Bearer ${accessToken}`;
-        } else {
-          alert('로그인이 필요한 서비스입니다.');
-          window.location.href = '/accounts/login';
-        }
-      }
-      return request;
-    },
-    error => {
-      console.error(error);
-      return Promise.reject(error);
-    }
-);
-
 customAxios.interceptors.response.use(
     response => {
-      let accessToken = response.headers['authorization'];
-      if (accessToken) {
-        sessionStorage.setItem('jwt', accessToken);
-      }
       return response;
-    },
-    error => {
+    }, error => {
       if (error.response.status === 401) {
         alert(error.response.data.errorDetail.message);
         window.location.href = '/accounts/login';


### PR DESCRIPTION
- 저장장소 Session Storage -> HttpOnly Cookie로 수정
- 이에 따른 JWT 발급 및 갱신 로직 수정

## JWT 저장 위치 변경
- 회원 인증 과정 (로그인) 이후 access token을 Session Storage에 저장했습니다.
- XSS 공격에 취약하다는 점을 알게되었고, Cookie에 HttpOnly 속성을 활성화 하는 방향으로 수정하였습니다.
- Cookie에 access token을 저장하는 방식을 채용함으로 토큰 발급, 갱신 로직 수정이 되었습니다.
